### PR TITLE
Standardize tokens

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,6 +29,9 @@ jobs:
 
     - name: Install dependencies of JS library
       run: npm ci
+    - name: Test deps
+      run: npm ci
+      working-directory: tests
     - name: Run integration tests
       run: npm test
       working-directory: tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,9 +29,6 @@ jobs:
 
     - name: Install dependencies of JS library
       run: npm ci
-    - name: Install integration tests
-      run: npm ci
-      working-directory: tests
     - name: Run integration tests
       run: npm test
       working-directory: tests

--- a/crates/y-sweet-server-core/src/api_types.rs
+++ b/crates/y-sweet-server-core/src/api_types.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 #[derive(Serialize)]
 pub struct NewDocResponse {
-    pub doc_id: String,
+    pub doc: String,
 }
 
 #[derive(Deserialize)]
@@ -35,9 +35,9 @@ pub struct AuthDocRequest {
 }
 
 #[derive(Serialize)]
-pub struct AuthDocResponse {
-    pub base_url: String,
-    pub doc_id: String,
+pub struct ClientToken {
+    pub url: String,
+    pub doc: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
 }

--- a/crates/y-sweet-server/src/main.rs
+++ b/crates/y-sweet-server/src/main.rs
@@ -163,11 +163,11 @@ async fn main() -> Result<()> {
                 println!();
                 println!("    // The token is hard-coded for simplicity of the example. Use a secret manager in production!");
                 println!(
-                    r#"    const params = {{"token": "{}"}})"#,
+                    r#"    const params = {{"url": "http://127.0.0.1:8080", "token": "{}"}})"#,
                     auth.server_token().bright_purple()
                 );
                 println!("    const docInfo = createDoc(params)");
-                println!("    const connectionKey = getConnectionKey(docInfo['doc_id'], params)");
+                println!("    const connectionKey = getClientToken(docInfo, {{}}, params)");
                 println!();
                 println!("Only use the server token on the server, do not expose the server token to clients.");
                 println!("getConnectionKey() will return a derived token that clients can use to scoped to a specific document.");

--- a/examples/src/app/code-editor/page.tsx
+++ b/examples/src/app/code-editor/page.tsx
@@ -8,10 +8,10 @@ type HomeProps = {
 }
 
 export default async function Home({ searchParams }: HomeProps) {
-  const connectionKey = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
+  const clientToken = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
 
   return (
-    <YDocProvider connectionKey={connectionKey} setQueryParam="doc">
+    <YDocProvider clientToken={clientToken} setQueryParam="doc">
       <CodeEditor />
     </YDocProvider>
   )

--- a/examples/src/app/color-grid/page.tsx
+++ b/examples/src/app/color-grid/page.tsx
@@ -8,10 +8,10 @@ type HomeProps = {
 }
 
 export default async function Home({ searchParams }: HomeProps) {
-  const connectionKey = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
+  const clientToken = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
 
   return (
-    <YDocProvider connectionKey={connectionKey} setQueryParam="doc">
+    <YDocProvider clientToken={clientToken} setQueryParam="doc">
       <ColorGrid />
     </YDocProvider>
   )

--- a/examples/src/app/debugger/page.tsx
+++ b/examples/src/app/debugger/page.tsx
@@ -1,5 +1,5 @@
 import { YDocProvider } from '@y-sweet/react'
-import { getConnectionKey } from '@y-sweet/sdk'
+import { getClientToken } from '@y-sweet/sdk'
 import { Console } from './Console'
 import { ENV_CONFIG } from '@/lib/config'
 
@@ -14,10 +14,10 @@ export default async function Home({ searchParams }: HomeProps) {
     return <p>Missing doc param</p>
   }
 
-  const connectionKey = await getConnectionKey(searchParams.doc, {}, ENV_CONFIG)
+  const clientToken = await getClientToken(searchParams.doc, {}, ENV_CONFIG)
 
   return (
-    <YDocProvider connectionKey={connectionKey}>
+    <YDocProvider clientToken={clientToken}>
       <Console />
     </YDocProvider>
   )

--- a/examples/src/app/presence/page.tsx
+++ b/examples/src/app/presence/page.tsx
@@ -8,10 +8,10 @@ type HomeProps = {
 }
 
 export default async function Home({ searchParams }: HomeProps) {
-  const connectionKey = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
+  const clientToken = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
 
   return (
-    <YDocProvider connectionKey={connectionKey} setQueryParam="doc">
+    <YDocProvider clientToken={clientToken} setQueryParam="doc">
       <Presence />
     </YDocProvider>
   )

--- a/examples/src/app/text-editor/page.tsx
+++ b/examples/src/app/text-editor/page.tsx
@@ -8,10 +8,10 @@ type HomeProps = {
 }
 
 export default async function Home({ searchParams }: HomeProps) {
-  const connectionKey = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
+  const clientToken = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
 
   return (
-    <YDocProvider connectionKey={connectionKey} setQueryParam="doc">
+    <YDocProvider clientToken={clientToken} setQueryParam="doc">
       <TextEditor />
     </YDocProvider>
   )

--- a/examples/src/app/to-do-list/page.tsx
+++ b/examples/src/app/to-do-list/page.tsx
@@ -8,10 +8,10 @@ type HomeProps = {
 }
 
 export default async function Home({ searchParams }: HomeProps) {
-  const connectionKey = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
+  const clientToken = await getOrCreateDoc(searchParams.doc, ENV_CONFIG)
 
   return (
-    <YDocProvider connectionKey={connectionKey} setQueryParam="doc">
+    <YDocProvider clientToken={clientToken} setQueryParam="doc">
       <ToDoList />
     </YDocProvider>
   )

--- a/js-pkg/react/package.json
+++ b/js-pkg/react/package.json
@@ -39,7 +39,6 @@
         "yjs": "^13.0.0"
     },
     "dependencies": {
-        "@y-sweet/sdk": "0.0.1",
         "y-protocols": "^1.0.5",
         "y-websocket": "^1.5.0"
     }

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -4,9 +4,8 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import type { ReactNode } from 'react'
 import { WebsocketProvider } from 'y-websocket'
 import * as Y from 'yjs'
-import { ClientToken } from '@y-sweet/sdk'
 import type { Awareness } from 'y-protocols/awareness'
-import { createYjsProvider } from './yjs-provider'
+import { ClientToken, createYjsProvider } from './yjs-provider'
 
 type YjsContextType = {
   doc: Y.Doc

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -4,7 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import type { ReactNode } from 'react'
 import { WebsocketProvider } from 'y-websocket'
 import * as Y from 'yjs'
-import { ConnectionKey } from '@y-sweet/sdk'
+import { ClientToken } from '@y-sweet/sdk'
 import type { Awareness } from 'y-protocols/awareness'
 import { createYjsProvider } from './yjs-provider'
 
@@ -73,7 +73,7 @@ type YDocProviderProps = {
   children: ReactNode
 
   /** Response of a `getConnectionKey` call, passed from server to client. */
-  connectionKey: ConnectionKey
+  clientToken: ClientToken
 
   /** If set to a string, the URL query parameter with this name
    * will be set to the doc id from connectionKey. */
@@ -81,7 +81,7 @@ type YDocProviderProps = {
 }
 
 export function YDocProvider(props: YDocProviderProps) {
-  const { children, connectionKey: auth } = props
+  const { children, clientToken: auth } = props
 
   const [ctx, setCtx] = useState<YjsContextType | null>(null)
 
@@ -98,15 +98,15 @@ export function YDocProvider(props: YDocProviderProps) {
       provider.destroy()
       doc.destroy()
     }
-  }, [auth.token, auth.base_url, auth.doc_id])
+  }, [auth.token, auth.url, auth.doc])
 
   useEffect(() => {
     if (props.setQueryParam) {
       const url = new URL(window.location.href)
-      url.searchParams.set(props.setQueryParam, auth.doc_id)
+      url.searchParams.set(props.setQueryParam, auth.doc)
       window.history.replaceState({}, '', url.toString())
     }
-  }, [props.setQueryParam, auth.doc_id])
+  }, [props.setQueryParam, auth.doc])
 
   if (ctx === null) return null
 

--- a/js-pkg/react/src/yjs-provider.ts
+++ b/js-pkg/react/src/yjs-provider.ts
@@ -1,16 +1,16 @@
 import { WebsocketProvider } from 'y-websocket'
 import * as Y from 'yjs'
-import { ConnectionKey } from '@y-sweet/sdk'
+import { ClientToken } from '@y-sweet/sdk'
 import type { Awareness } from 'y-protocols/awareness'
 
 export function createYjsProvider(
   doc: Y.Doc,
-  connectionKey: ConnectionKey,
+  clientToken: ClientToken,
   extraOptions: Partial<WebsocketParams> = {},
 ) {
-  const params = connectionKey.token ? { token: connectionKey.token } : undefined
+  const params = clientToken.token ? { token: clientToken.token } : undefined
 
-  const provider = new WebsocketProvider(connectionKey.base_url, connectionKey.doc_id, doc, {
+  const provider = new WebsocketProvider(clientToken.url, clientToken.doc, doc, {
     params,
     ...extraOptions,
   })

--- a/js-pkg/react/src/yjs-provider.ts
+++ b/js-pkg/react/src/yjs-provider.ts
@@ -1,7 +1,12 @@
 import { WebsocketProvider } from 'y-websocket'
 import * as Y from 'yjs'
-import { ClientToken } from '@y-sweet/sdk'
 import type { Awareness } from 'y-protocols/awareness'
+
+export type ClientToken = {
+  url: string
+  doc: string
+  token?: string
+}
 
 export function createYjsProvider(
   doc: Y.Doc,

--- a/js-pkg/sdk/src/main.ts
+++ b/js-pkg/sdk/src/main.ts
@@ -119,9 +119,7 @@ export async function getClientToken(
   return await manager.getClientToken(docId, request)
 }
 
-export async function createDoc(
-  options?: ServerToken | string,
-): Promise<DocCreationResult> {
+export async function createDoc(options?: ServerToken | string): Promise<DocCreationResult> {
   const manager = new DocumentManager(options)
   return await manager.createDoc()
 }


### PR DESCRIPTION
This standardizes `token` as the name for a type that provides information for connecting to a resource, comprising of "server tokens" for connecting from the server and "client tokens" for connecting to a particular document from the client.

The fields each token has in common are also standardized.

Previously, we referred to a `ClientToken` interchangeably as an "AuthDocResponse" and as a "connection key", which is confusing.

It also changes field names to one-word names: `doc_id` -> `doc`; `base_url` and `endpoint` -> `url`. This way they are idiomatic on both the rust side and JS side.

This is a breaking change, so I wanted to do it before launching.