### PR TITLE
fix todolist mobile style

### DIFF
--- a/examples/src/app/to-do-list/ToDoList.tsx
+++ b/examples/src/app/to-do-list/ToDoList.tsx
@@ -61,10 +61,10 @@ export function ToDoItem({ item }: ToDoItemProps) {
 
   return (
     <div>
-      <label className="flex flex-row space-x-2">
+      <label className="flex flex-row space-x-2 items-center">
         <input
           type="checkbox"
-          className="w-6 cursor-pointer"
+          className="w-6 h-6 cursor-pointer"
           checked={item.get('done')}
           onChange={clickCallback}
         />


### PR DESCRIPTION
On my iPhone, the checkbox on the todolist wasn't vertically aligned with the text next to it.