### PR TITLE
Allow using without a store

### DIFF
--- a/crates/y-sweet-core/src/doc_sync.rs
+++ b/crates/y-sweet-core/src/doc_sync.rs
@@ -20,7 +20,11 @@ impl DocWithSyncKv {
         self.sync_kv.clone()
     }
 
-    pub async fn new<F>(key: &str, store: Option<Arc<Box<dyn Store>>>, dirty_callback: F) -> Result<Self>
+    pub async fn new<F>(
+        key: &str,
+        store: Option<Arc<Box<dyn Store>>>,
+        dirty_callback: F,
+    ) -> Result<Self>
     where
         F: Fn() + Send + Sync + 'static,
     {

--- a/crates/y-sweet-core/src/doc_sync.rs
+++ b/crates/y-sweet-core/src/doc_sync.rs
@@ -20,7 +20,7 @@ impl DocWithSyncKv {
         self.sync_kv.clone()
     }
 
-    pub async fn new<F>(key: &str, store: Arc<Box<dyn Store>>, dirty_callback: F) -> Result<Self>
+    pub async fn new<F>(key: &str, store: Option<Arc<Box<dyn Store>>>, dirty_callback: F) -> Result<Self>
     where
         F: Fn() + Send + Sync + 'static,
     {

--- a/crates/y-sweet-core/src/sync_kv.rs
+++ b/crates/y-sweet-core/src/sync_kv.rs
@@ -13,7 +13,7 @@ use yrs_kvstore::{DocOps, KVEntry};
 
 pub struct SyncKv {
     data: Arc<Mutex<BTreeMap<Vec<u8>, Vec<u8>>>>,
-    store: Arc<Box<dyn Store>>,
+    store: Option<Arc<Box<dyn Store>>>,
     key: String,
     dirty: AtomicBool,
     dirty_callback: Box<dyn Fn() + Send + Sync>,
@@ -21,14 +21,19 @@ pub struct SyncKv {
 
 impl SyncKv {
     pub async fn new<Callback: Fn() + Send + Sync + 'static>(
-        store: Arc<Box<dyn Store>>,
+        store: Option<Arc<Box<dyn Store>>>,
         key: &str,
         callback: Callback,
     ) -> Result<Self> {
         let key = format!("{}/data.ysweet", key);
-        let data = if let Some(snapshot) = store.get(&key).await? {
-            tracing::info!(size=?snapshot.len(), "Loaded snapshot");
-            bincode::deserialize(&snapshot)?
+
+        let data = if let Some(store) = &store {
+            if let Some(snapshot) = store.get(&key).await? {
+                tracing::info!(size=?snapshot.len(), "Loaded snapshot");
+                bincode::deserialize(&snapshot)?
+            } else {
+                BTreeMap::new()
+            }
         } else {
             BTreeMap::new()
         };
@@ -50,12 +55,15 @@ impl SyncKv {
     }
 
     pub async fn persist(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let snapshot = {
-            let data = self.data.lock().unwrap();
-            bincode::serialize(&*data)?
-        };
-        tracing::info!(size=?snapshot.len(), "Persisting snapshot");
-        self.store.set(&self.key, snapshot).await?;
+        if let Some(store) = &self.store {
+            let snapshot = {
+                let data = self.data.lock().unwrap();
+                bincode::serialize(&*data)?
+            };
+
+            tracing::info!(size=?snapshot.len(), "Persisting snapshot");
+            store.set(&self.key, snapshot).await?;
+        }
         self.dirty.store(false, Ordering::Relaxed);
         Ok(())
     }
@@ -222,7 +230,7 @@ mod test {
     async fn calls_sync_callback() {
         let store = MemoryStore::default();
         let c = CallbackCounter::default();
-        let sync_kv = SyncKv::new(Arc::new(Box::new(store.clone())), "foo", c.callback())
+        let sync_kv = SyncKv::new(Some(Arc::new(Box::new(store.clone()))), "foo", c.callback())
             .await
             .unwrap();
 
@@ -246,7 +254,7 @@ mod test {
         let store = MemoryStore::default();
 
         {
-            let sync_kv = SyncKv::new(Arc::new(Box::new(store.clone())), "foo", || ())
+            let sync_kv = SyncKv::new(Some(Arc::new(Box::new(store.clone()))), "foo", || ())
                 .await
                 .unwrap();
 
@@ -259,7 +267,7 @@ mod test {
         }
 
         {
-            let sync_kv = SyncKv::new(Arc::new(Box::new(store.clone())), "foo", || ())
+            let sync_kv = SyncKv::new(Some(Arc::new(Box::new(store.clone()))), "foo", || ())
                 .await
                 .unwrap();
 

--- a/crates/y-sweet-worker/Cargo.lock
+++ b/crates/y-sweet-worker/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet-core"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/y-sweet-worker/src/durable_object.rs
+++ b/crates/y-sweet-worker/src/durable_object.rs
@@ -22,7 +22,7 @@ impl YServe {
             let mut context = ServerContext::from_request(req, &self.env).unwrap();
             let storage = Arc::new(self.state.storage());
 
-            let store = context.store();
+            let store = Some(context.store());
             let storage = Threadless(storage);
             let doc = DocWithSyncKv::new(doc_id, store, move || {
                 let storage = storage.clone();

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -86,7 +86,7 @@ async fn new_doc(
     check_server_token(&req, ctx.data.auth()?)?;
 
     let doc_id = nanoid::nanoid!();
-    let store = ctx.data.store();
+    let store = Some(ctx.data.store());
     let dwskv = DocWithSyncKv::new(&doc_id, store, || {}).await.unwrap();
 
     dwskv.sync_kv().persist().await.unwrap();

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -27,7 +27,7 @@ struct Opts {
 #[derive(Subcommand)]
 enum ServSubcommand {
     Serve {
-        store_path: String,
+        store: Option<String>,
 
         #[clap(long, default_value = "8080")]
         port: u16,
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
             port,
             host,
             checkpoint_freq_seconds,
-            store_path,
+            store,
             auth,
             use_https,
         } => {
@@ -103,7 +103,12 @@ async fn main() -> Result<()> {
                 *port,
             );
 
-            let store = get_store_from_opts(store_path)?;
+            let store = if let Some(store) = store {
+                Some(get_store_from_opts(&store)?)
+            } else {
+                tracing::warn!("No store set. Documents will be stored in memory only.");
+                None
+            };
 
             let server = server::Server::new(
                 store,


### PR DESCRIPTION
Currently we require a store to be passed on the cli. For local development, it's sometimes nice to use an ephemeral in-memory store without persisting.

This PR changes `store` from a positional to an explicit argument. If it is not passed, document state is not persisted.

After #56 is merged, which adds a `--prod` flag, we should probably fail to start with an in-memory store (or at least log an error-level log) if `--prod` is passed.