### PR TITLE
Allow region to be specified via env vars

### DIFF
--- a/crates/y-sweet/Cargo.toml
+++ b/crates/y-sweet/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.28"
 lib0 = "0.16.9"
 nanoid = "0.4.0"
 pasetors = { version = "0.6.7", features = ["serde"] }
-rust-s3 = { version = "0.33.0", features = ["tokio-rustls-tls"], default-features = false }
+rust-s3 = { version = "0.33.0", features = ["tokio-rustls-tls", "fail-on-err"], default-features = false }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.103"
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -18,6 +18,8 @@ use y_sweet_core::{auth::Authenticator, store::Store};
 mod server;
 mod stores;
 
+const DEFAULT_S3_REGION: Region = Region::UsEast1;
+
 #[derive(Parser)]
 struct Opts {
     #[clap(subcommand)]
@@ -57,8 +59,12 @@ fn get_store_from_opts(store_path: &str) -> Result<Box<dyn Store>> {
                 region
             }
             Err(e) => {
-                tracing::warn!(error=?e, "Failed to get region from environment, using default.");
-                Region::UsEast1
+                tracing::warn!(
+                    error=?e,
+                    "Failed to get region from environment, using default ({}).",
+                    DEFAULT_S3_REGION
+                );
+                DEFAULT_S3_REGION
             }
         };
         let url = url::Url::parse(store_path)?;

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -68,23 +68,26 @@ impl Server {
                 .unwrap_or_default()
     }
 
-    pub async fn create_doc(&self) -> String {
+    pub async fn create_doc(&self) -> Result<String> {
         let doc_id = nanoid::nanoid!();
-        self.load_doc(&doc_id).await;
+        self.load_doc(&doc_id).await?;
         tracing::info!(doc_id=?doc_id, "Created doc");
-        doc_id
+        Ok(doc_id)
     }
 
-    pub async fn load_doc(&self, doc_id: &str) {
+    pub async fn load_doc(&self, doc_id: &str) -> Result<()> {
         let (send, mut recv) = channel(1024);
 
         let dwskv = DocWithSyncKv::new(doc_id, self.store.clone(), move || {
             send.try_send(()).unwrap();
         })
-        .await
-        .unwrap();
+        .await?;
 
-        dwskv.sync_kv().persist().await.unwrap();
+        dwskv
+            .sync_kv()
+            .persist()
+            .await
+            .map_err(|e| anyhow!("Error persisting: {:?}", e))?;
 
         {
             let sync_kv = dwskv.sync_kv();
@@ -118,6 +121,7 @@ impl Server {
         }
 
         self.docs.insert(doc_id.to_string(), dwskv);
+        Ok(())
     }
 
     pub async fn get_or_create_doc(
@@ -126,7 +130,7 @@ impl Server {
     ) -> Result<MappedRef<String, DocWithSyncKv, DocWithSyncKv>> {
         if !self.docs.contains_key(doc_id) {
             tracing::info!(doc_id=?doc_id, "Loading doc");
-            self.load_doc(doc_id).await;
+            self.load_doc(doc_id).await?;
         }
 
         Ok(self
@@ -241,7 +245,10 @@ async fn new_doc(
 ) -> Result<Json<NewDocResponse>, StatusCode> {
     server_state.check_auth(authorization)?;
 
-    let doc_id = server_state.create_doc().await;
+    let doc_id = server_state.create_doc().await.map_err(|d| {
+        tracing::error!(?d, "Failed to create doc");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     Ok(Json(NewDocResponse { doc: doc_id }))
 }
 


### PR DESCRIPTION
- Allow region to be specified via env vars.
- Remove some panics and add some error context.
- Fixed an issue where 404s were not being propagated correctly from s3-rust because a feature flag was disabled.