### PR TITLE
Only show presence of other users by default

### DIFF
--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -31,18 +31,25 @@ export function useAwareness(): Awareness {
   return yjsCtx.provider.awareness
 }
 
-export function usePresence<T extends Record<string, any>>(): [
-  Map<number, T>,
-  (presence: T) => void,
-] {
+type UsePresenceOptions = {
+  excludeSelf?: boolean
+}
+
+export function usePresence<T extends Record<string, any>>(
+  options?: UsePresenceOptions,
+): [Map<number, T>, (presence: T) => void] {
   const awareness = useAwareness()
   const [presence, setPresence] = useState<Map<number, T>>(new Map())
+
+  const excludeSelf = options?.excludeSelf ?? true
 
   useEffect(() => {
     if (awareness) {
       const callback = () => {
         const map = new Map()
         awareness.getStates().forEach((state, clientID) => {
+          if (excludeSelf && clientID === awareness.clientID) return
+
           if (Object.keys(state).length > 0) {
             map.set(clientID, state)
           }


### PR DESCRIPTION
In most cases, the presence indicator for the local user does not follow the same code path as remote users (text cursors, pointers, etc.), so this removes the local presence by default.