### PR TITLE
Allow obtaining a setPresence handle without subscribing to presence

### DIFF
--- a/examples/src/app/presence/Presence.tsx
+++ b/examples/src/app/presence/Presence.tsx
@@ -9,13 +9,16 @@ export function Presence() {
   const myColor = useRef(COLORS[Math.floor(Math.random() * COLORS.length)])
   const [presence, setPresence] = usePresence<{ x: number; y: number; color: string }>()
 
-  const updatePresence = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    setPresence({
-      x: e.clientX - e.currentTarget.offsetLeft,
-      y: e.clientY - e.currentTarget.offsetTop,
-      color: myColor.current,
-    })
-  }, [setPresence])
+  const updatePresence = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      setPresence({
+        x: e.clientX - e.currentTarget.offsetLeft,
+        y: e.clientY - e.currentTarget.offsetTop,
+        color: myColor.current,
+      })
+    },
+    [setPresence],
+  )
 
   return (
     <div

--- a/examples/src/app/presence/Presence.tsx
+++ b/examples/src/app/presence/Presence.tsx
@@ -15,7 +15,7 @@ export function Presence() {
       y: e.clientY - e.currentTarget.offsetTop,
       color: myColor.current,
     })
-  }, [])
+  }, [setPresence])
 
   return (
     <div

--- a/examples/src/app/presence/Presence.tsx
+++ b/examples/src/app/presence/Presence.tsx
@@ -1,13 +1,16 @@
 'use client'
 
-import { usePresence } from '@y-sweet/react'
+import { usePresence, usePresenceSetter } from '@y-sweet/react'
 import { useCallback, useRef } from 'react'
 
 const COLORS = ['bg-red-500', 'bg-blue-500', 'bg-green-500', 'bg-purple-500', 'bg-pink-500']
 
+type Presence = { x: number; y: number; color: string }
+
 export function Presence() {
   const myColor = useRef(COLORS[Math.floor(Math.random() * COLORS.length)])
-  const [presence, setPresence] = usePresence<{ x: number; y: number; color: string }>()
+  const presence = usePresence<Presence>()
+  const setPresence = usePresenceSetter<Presence>()
 
   const updatePresence = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {

--- a/examples/src/app/tree-crdt/TreeView.tsx
+++ b/examples/src/app/tree-crdt/TreeView.tsx
@@ -207,7 +207,7 @@ export function TreeView() {
     return () => {
       tree.setOnChange(undefined)
     }
-  }, [])
+  }, [treeMap])
 
   return (
     <div className="p-4 sm:p-8 space-y-3">

--- a/examples/src/app/voxels/VoxelEditor.tsx
+++ b/examples/src/app/voxels/VoxelEditor.tsx
@@ -129,16 +129,20 @@ type PresenceVoxel = {
 export function PresenceVoxels() {
   const presence = useGetPresence<PresenceVoxel>()
 
-  return <>{Array.from(presence.entries()).map(([id, user]) => {
-    if (user.position === null) return null
+  return (
+    <>
+      {Array.from(presence.entries()).map(([id, user]) => {
+        if (user.position === null) return null
 
-    return (
-      <MovingVoxel
-        key={id}
-        voxel={{ position: user.position, color: user.color, opacity: 0.5 }}
-      />
-    )
-  })}</>
+        return (
+          <MovingVoxel
+            key={id}
+            voxel={{ position: user.position, color: user.color, opacity: 0.5 }}
+          />
+        )
+      })}
+    </>
+  )
 }
 
 export function VoxelEditor() {

--- a/examples/src/app/voxels/VoxelEditor.tsx
+++ b/examples/src/app/voxels/VoxelEditor.tsx
@@ -3,7 +3,7 @@
 import { OrbitControls } from '@react-three/drei'
 import { Canvas, ThreeEvent, useFrame } from '@react-three/fiber'
 import { Compact } from '@uiw/react-color'
-import { useGetPresence, useMap, usePresenceSetter } from '@y-sweet/react'
+import { usePresence, useMap, usePresenceSetter } from '@y-sweet/react'
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { Vector3, Vector3Tuple } from 'three'
 
@@ -127,7 +127,7 @@ type PresenceVoxel = {
 }
 
 export function PresenceVoxels() {
-  const presence = useGetPresence<PresenceVoxel>()
+  const presence = usePresence<PresenceVoxel>()
 
   return (
     <>

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -35,9 +35,24 @@ type UsePresenceOptions = {
   includeSelf?: boolean
 }
 
-export function usePresence<T extends Record<string, any>>(
+export function usePresenceSetter<T extends Record<string, any>>(): (presence: T) => void {
+  const awareness = useAwareness()
+
+  const setLocalPresence = useCallback(
+    (localState: any) => {
+      if (awareness) {
+        awareness.setLocalState(localState)
+      }
+    },
+    [awareness],
+  )
+
+  return setLocalPresence
+}
+
+export function useGetPresence<T extends Record<string, any>>(
   options?: UsePresenceOptions,
-): [Map<number, T>, (presence: T) => void] {
+): Map<number, T> {
   const awareness = useAwareness()
   const [presence, setPresence] = useState<Map<number, T>>(new Map())
 
@@ -64,16 +79,15 @@ export function usePresence<T extends Record<string, any>>(
     }
   }, [awareness])
 
-  const setLocalPresence = useCallback(
-    (localState: any) => {
-      if (awareness) {
-        awareness.setLocalState(localState)
-      }
-    },
-    [awareness],
-  )
+  return presence
+}
 
-  return [presence, setLocalPresence]
+export function usePresence<T extends Record<string, any>>(): [Map<number, T>, (presence: T) => void] {
+  const awareness = useAwareness()
+  const presence = useGetPresence<T>()
+  const setPresence = usePresenceSetter<T>()
+
+  return [presence, setPresence]
 }
 
 type YDocProviderProps = {

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -82,7 +82,10 @@ export function useGetPresence<T extends Record<string, any>>(
   return presence
 }
 
-export function usePresence<T extends Record<string, any>>(): [Map<number, T>, (presence: T) => void] {
+export function usePresence<T extends Record<string, any>>(): [
+  Map<number, T>,
+  (presence: T) => void,
+] {
   const awareness = useAwareness()
   const presence = useGetPresence<T>()
   const setPresence = usePresenceSetter<T>()

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -50,7 +50,7 @@ export function usePresenceSetter<T extends Record<string, any>>(): (presence: T
   return setLocalPresence
 }
 
-export function useGetPresence<T extends Record<string, any>>(
+export function usePresence<T extends Record<string, any>>(
   options?: UsePresenceOptions,
 ): Map<number, T> {
   const awareness = useAwareness()
@@ -80,17 +80,6 @@ export function useGetPresence<T extends Record<string, any>>(
   }, [awareness])
 
   return presence
-}
-
-export function usePresence<T extends Record<string, any>>(): [
-  Map<number, T>,
-  (presence: T) => void,
-] {
-  const awareness = useAwareness()
-  const presence = useGetPresence<T>()
-  const setPresence = usePresenceSetter<T>()
-
-  return [presence, setPresence]
 }
 
 type YDocProviderProps = {

--- a/js-pkg/sdk/tsup.config.ts
+++ b/js-pkg/sdk/tsup.config.ts
@@ -1,11 +1,11 @@
-import { defineConfig } from "tsup"
+import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ["src/main.ts"],
+  entry: ['src/main.ts'],
   dts: true,
   splitting: true,
   clean: true,
-  target: "es2020",
-  format: ["esm", "cjs"],
+  target: 'es2020',
+  format: ['esm', 'cjs'],
   sourcemap: true,
 })


### PR DESCRIPTION
Introduces `useGetPresence` which gets and subscribes to presence, and `usePresenceSetter` which returns a setter but does not subscribe. This allows the presence rerender to be pushed down the component tree while using the setter elsewhere in the tree. 

The existing `usePresence` hook behavior is unchanged, but it is rewritten in terms of the new hooks. I considered deprecating it, but since `useGetPresence` and `usePresenceSetter` are both generic functions, I think it's useful to have a way to call them both with the same type parameter -- open to thoughts on this.