### PR TITLE
Fix url prefix bug

### DIFF
--- a/crates/y-sweet-worker/src/error.rs
+++ b/crates/y-sweet-worker/src/error.rs
@@ -14,10 +14,7 @@ pub enum Error {
     #[error("Client auth header provided but not valid.")]
     BadClientAuthHeader,
     #[error("Configuration error parsing field '{field}' with value '{value}'.")]
-    ConfigurationError {
-        field: String,
-        value: String,
-    },
+    ConfigurationError { field: String, value: String },
     #[error("Missing 'host' header.")]
     MissingHostHeader,
     #[error("No such document.")]
@@ -33,7 +30,7 @@ impl Error {
         match self {
             Self::ExpectedAuthHeader => 401,
             Self::BadAuthHeader => 403,
-            Self::ConfigurationError {..} => 500,
+            Self::ConfigurationError { .. } => 500,
             Self::MissingHostHeader => 400,
             Self::NoSuchDocument => 404,
             Self::UpstreamConnectionError => 500,
@@ -65,7 +62,7 @@ impl<T: Serialize> IntoResponse<T> for Result<T, Error> {
             Err(err) => {
                 console_error!("Error: {:?}", err);
                 err.into()
-            },
+            }
         }
     }
 }

--- a/crates/y-sweet-worker/src/error.rs
+++ b/crates/y-sweet-worker/src/error.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use thiserror::Error;
 use worker::Response;
+use worker_sys::console_error;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
@@ -12,8 +13,11 @@ pub enum Error {
     ExpectedClientAuthHeader,
     #[error("Client auth header provided but not valid.")]
     BadClientAuthHeader,
-    #[error("Configuration error.")]
-    ConfigurationError,
+    #[error("Configuration error parsing field '{field}' with value '{value}'.")]
+    ConfigurationError {
+        field: String,
+        value: String,
+    },
     #[error("Missing 'host' header.")]
     MissingHostHeader,
     #[error("No such document.")]
@@ -29,7 +33,7 @@ impl Error {
         match self {
             Self::ExpectedAuthHeader => 401,
             Self::BadAuthHeader => 403,
-            Self::ConfigurationError => 500,
+            Self::ConfigurationError {..} => 500,
             Self::MissingHostHeader => 400,
             Self::NoSuchDocument => 404,
             Self::UpstreamConnectionError => 500,
@@ -58,7 +62,10 @@ impl<T: Serialize> IntoResponse<T> for Result<T, Error> {
     fn into_response(self) -> Result<Response, worker::Error> {
         match self {
             Ok(response) => Response::from_json(&response),
-            Err(err) => err.into(),
+            Err(err) => {
+                console_error!("Error: {:?}", err);
+                err.into()
+            },
         }
     }
 }

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -130,10 +130,12 @@ async fn auth_doc(
         match parsed.scheme() {
             "http" => parsed.set_scheme("ws").map_err(|_| Error::InternalError)?,
             "https" => parsed.set_scheme("wss").map_err(|_| Error::InternalError)?,
-            _ => return Err(Error::ConfigurationError {
-                field: "url_prefix".to_string(),
-                value: url_prefix.to_string(),
-            }),
+            _ => {
+                return Err(Error::ConfigurationError {
+                    field: "url_prefix".to_string(),
+                    value: url_prefix.to_string(),
+                })
+            }
         };
         format!("{parsed}/doc/ws")
     } else {

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -123,15 +123,19 @@ async fn auth_doc(
         .map(|auth| auth.gen_doc_token(&doc_id, get_time_millis_since_epoch()));
 
     let url = if let Some(url_prefix) = &ctx.data.config.url_prefix {
-        let mut parsed = Url::parse(url_prefix).map_err(|_| Error::ConfigurationError)?;
+        let mut parsed = Url::parse(url_prefix).map_err(|_| Error::ConfigurationError {
+            field: "url_prefix".to_string(),
+            value: url_prefix.to_string(),
+        })?;
         match parsed.scheme() {
             "http" => parsed.set_scheme("ws").map_err(|_| Error::InternalError)?,
             "https" => parsed.set_scheme("wss").map_err(|_| Error::InternalError)?,
-            _ => return Err(Error::ConfigurationError),
+            _ => return Err(Error::ConfigurationError {
+                field: "url_prefix".to_string(),
+                value: url_prefix.to_string(),
+            }),
         };
-        let result = parsed.join("/doc/ws").unwrap();
-
-        result.to_string()
+        format!("{parsed}/doc/ws")
     } else {
         let host = req
             .headers()

--- a/crates/y-sweet-worker/src/server_context.rs
+++ b/crates/y-sweet-worker/src/server_context.rs
@@ -35,7 +35,10 @@ impl ServerContext {
                 auth_key.to_owned()
             };
 
-            self.auth = Some(Authenticator::new(&auth_key).map_err(|_| Error::ConfigurationError)?);
+            self.auth = Some(Authenticator::new(&auth_key).map_err(|_| Error::ConfigurationError {
+                field: "auth_key".to_string(),
+                value: auth_key,
+            })?);
         }
 
         Ok(Some(self.auth.as_ref().unwrap()))

--- a/crates/y-sweet-worker/src/server_context.rs
+++ b/crates/y-sweet-worker/src/server_context.rs
@@ -35,10 +35,13 @@ impl ServerContext {
                 auth_key.to_owned()
             };
 
-            self.auth = Some(Authenticator::new(&auth_key).map_err(|_| Error::ConfigurationError {
-                field: "auth_key".to_string(),
-                value: auth_key,
-            })?);
+            self.auth =
+                Some(
+                    Authenticator::new(&auth_key).map_err(|_| Error::ConfigurationError {
+                        field: "auth_key".to_string(),
+                        value: auth_key,
+                    })?,
+                );
         }
 
         Ok(Some(self.auth.as_ref().unwrap()))

--- a/crates/y-sweet-worker/wrangler.toml
+++ b/crates/y-sweet-worker/wrangler.toml
@@ -23,7 +23,6 @@ bindings = [
 ]
 
 [env.staging]
-vars.USE_HTTPS = "true"
 vars.WORKERS_RS_VERSION = "0.0.11"
 
 [env.staging.durable_objects]


### PR DESCRIPTION
This fixes a bug where the path component of a configured `url_prefix` was not preserved.

Also adds some error logging and metadata around configuration errors.