### PR TITLE
Allow url-safe base64 for auth

### DIFF
--- a/crates/y-sweet-core/src/auth.rs
+++ b/crates/y-sweet-core/src/auth.rs
@@ -1,4 +1,8 @@
-use base64::{engine::general_purpose, Engine};
+use base64::{
+    alphabet::{STANDARD, URL_SAFE},
+    engine::{general_purpose, DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
+    Engine,
+};
 use bincode::Options;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -61,9 +65,18 @@ fn b64_encode(bytes: &[u8]) -> String {
 }
 
 fn b64_decode(str: &str) -> Result<Vec<u8>, AuthError> {
-    general_purpose::STANDARD
-        .decode(str)
-        .map_err(|_| AuthError::InvalidToken)
+    let config =
+        GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent);
+    let engine = GeneralPurpose::new(&STANDARD, config);
+
+    if let Ok(result) = engine.decode(str) {
+        return Ok(result);
+    }
+
+    // If we failed with STANDARD, try with URL_SAFE.
+    let engine = GeneralPurpose::new(&URL_SAFE, config);
+
+    engine.decode(str).map_err(|_| AuthError::InvalidToken)
 }
 
 mod b64 {
@@ -162,6 +175,21 @@ impl Authenticator {
         &self.server_token
     }
 
+    pub fn verify_server_token(
+        &self,
+        token: &str,
+        current_time_epoch_millis: u64,
+    ) -> Result<(), AuthError> {
+        let payload = Payload::verify(token, &self.private_key, current_time_epoch_millis)?;
+        match payload {
+            Payload {
+                payload: Permission::Server,
+                ..
+            } => Ok(()),
+            _ => Err(AuthError::InvalidResource),
+        }
+    }
+
     pub fn private_key(&self) -> String {
         b64_encode(&self.private_key)
     }
@@ -205,7 +233,7 @@ impl Authenticator {
     }
 
     pub fn gen_key() -> Result<Authenticator, AuthError> {
-        let key = rand::thread_rng().gen::<[u8; 32]>();
+        let key = rand::thread_rng().gen::<[u8; 30]>();
         let key = b64_encode(&key);
 
         let authenticator = Authenticator::new(&key)?;
@@ -216,6 +244,17 @@ impl Authenticator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_flex_b64() {
+        let expect = [3, 242, 3, 248, 6, 220, 118];
+
+        assert_eq!(b64_decode("A/ID+Abcdg==").unwrap(), expect);
+        assert_eq!(b64_decode("A/ID+Abcdg").unwrap(), expect);
+
+        assert_eq!(b64_decode("A_ID-Abcdg==").unwrap(), expect);
+        assert_eq!(b64_decode("A_ID-Abcdg").unwrap(), expect);
+    }
 
     #[test]
     fn test_simple_auth() {

--- a/crates/y-sweet-core/src/auth.rs
+++ b/crates/y-sweet-core/src/auth.rs
@@ -1,6 +1,6 @@
 use base64::{
     alphabet::{STANDARD, URL_SAFE},
-    engine::{general_purpose, DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
+    engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
     Engine,
 };
 use bincode::Options;
@@ -59,8 +59,10 @@ fn bincode_decode<'a, T: Deserialize<'a>>(bytes: &'a [u8]) -> Result<T, bincode:
 }
 
 fn b64_encode(bytes: &[u8]) -> String {
+    let config = GeneralPurposeConfig::new().with_encode_padding(false);
+    let engine = GeneralPurpose::new(&URL_SAFE, config);
     let mut buf = String::new();
-    general_purpose::STANDARD.encode_string(bytes, &mut buf);
+    engine.encode_string(bytes, &mut buf);
     buf
 }
 
@@ -254,6 +256,13 @@ mod tests {
 
         assert_eq!(b64_decode("A_ID-Abcdg==").unwrap(), expect);
         assert_eq!(b64_decode("A_ID-Abcdg").unwrap(), expect);
+    }
+
+    #[test]
+    fn test_b64_encode_options() {
+        let data = [3, 242, 3, 248, 6, 220, 118];
+
+        assert_eq!(b64_encode(&data), "A_ID-Abcdg");
     }
 
     #[test]

--- a/crates/y-sweet-worker/Cargo.lock
+++ b/crates/y-sweet-worker/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet-core"
-version = "0.0.1"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet-worker"
-version = "0.1.0"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -65,7 +65,10 @@ fn check_server_token(
         let auth_header_val = auth_header.as_deref().ok_or(Error::ExpectedAuthHeader)?;
 
         if let Some(token) = auth_header_val.strip_prefix("Bearer ") {
-            if auth.server_token() != token {
+            if auth
+                .verify_server_token(&token, get_time_millis_since_epoch())
+                .is_err()
+            {
                 return Err(Error::BadAuthHeader);
             }
         } else {

--- a/crates/y-sweet/src/server.rs
+++ b/crates/y-sweet/src/server.rs
@@ -152,7 +152,9 @@ impl Server {
     ) -> Result<(), StatusCode> {
         if let Some(auth) = &self.authenticator {
             if let Some(TypedHeader(headers::Authorization(bearer))) = header {
-                if bearer.token() == auth.server_token() {
+                if let Ok(()) =
+                    auth.verify_server_token(&bearer.token(), current_time_epoch_millis())
+                {
                     return Ok(());
                 }
             }


### PR DESCRIPTION
Currently we generate URLs that look like this:

```
http://2Fl8XmOtwEMXkXLIlWwWi7kylAXTuJ+PPyQBWKM%3D@127.0.0.1:8080/project/C8az-GJYXKPNyYP4HRgyl/
```

These are uglier than they need to be because they use non-URL-safe characters. If we instead use URL-safe base64 without padding, we could create a slightly nicer looking URL:

```
http://2Fl8XmOtwEMXkXLIlWwWi7kylAXTuJ-PPyQBWKM@127.0.0.1:8080/project/C8az-GJYXKPNyYP4HRgyl/
```

Merely switching would work, but break existing tokens, so instead I opt to (at least for an interim period) accept both encodings.

In order to accept both encodings for server tokens, instead of comparing the base64-encoded strings, we need to actually validate the token. This has the benefit of enabling expiring server tokens.

I didn't do this initially because I thought HTTP required a Bearer token to be (standard) base64 encoded, but [the RFC](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1) merely requires that the token match a regular expression which includes both standard and URL-encoded base64.