### PR TITLE
Add support for key ID in tokens

### DIFF
--- a/crates/y-sweet/src/cli.rs
+++ b/crates/y-sweet/src/cli.rs
@@ -11,7 +11,7 @@ pub fn print_server_url(auth: Option<&Authenticator>, url_prefix: Option<&Url>, 
     };
 
     if let Some(auth) = auth {
-        url.set_username(auth.server_token()).unwrap();
+        url.set_username(&auth.server_token()).unwrap();
     }
 
     let token = url.to_string();


### PR DESCRIPTION
This adds support for a concept of "key IDs" in token authentication.

This is a feature of the "core" library only, and is not exposed by this PR in either the native or Cloudflare server.

Key IDs are used by consumers of the core library by calling `with_key_id(key_id)`
on an `Authenticator`, which returns a new `Authenticator` using that key ID.

An `Authenticator` with a key ID has its behavior changed:

- When generating keys, it prepends `{key_id}.`.
- When validating tokens, it expects to find `{key_id}.` as a prefix, which is stripped
  before validating the token as usual.