### PR TITLE
Allow not observing object in react hooks

### DIFF
--- a/examples/src/app/code-editor/CodeEditor.tsx
+++ b/examples/src/app/code-editor/CodeEditor.tsx
@@ -16,7 +16,7 @@ if (typeof navigator !== 'undefined') {
 import './caret.css'
 
 export function CodeEditor() {
-  const yText = useText('text')
+  const yText = useText('text', { observe: 'none' })
   const awareness = useAwareness()
   const editorRef = useRef<EditorFromTextArea | null>(null)
   const bindingRef = useRef<CodemirrorBinding | null>(null)

--- a/examples/src/app/text-editor/TextEditor.tsx
+++ b/examples/src/app/text-editor/TextEditor.tsx
@@ -9,7 +9,7 @@ import CopyLink from '@/components/CopyLink'
 import 'quill/dist/quill.snow.css'
 
 export function TextEditor() {
-  const yText = useText('text')
+  const yText = useText('text', {observe: 'none'})
   const awareness = useAwareness()
   const editorRef = useRef<HTMLDivElement | null>(null)
   const bindingRef = useRef<QuillBinding | null>(null)

--- a/examples/src/app/tldraw/useYjsStore.ts
+++ b/examples/src/app/tldraw/useYjsStore.ts
@@ -18,8 +18,7 @@ import {
 import { useYjsProvider } from '@y-sweet/react'
 import { useMap } from '@y-sweet/react'
 import { useYDoc } from '@y-sweet/react'
-import { useEffect, useMemo, useState } from 'react'
-import { WebsocketProvider } from 'y-websocket'
+import { useEffect, useState } from 'react'
 import * as Y from 'yjs'
 
 export function useYjsStore() {
@@ -30,7 +29,7 @@ export function useYjsStore() {
 
   const doc = useYDoc()
   const room = useYjsProvider()
-  const yRecords = useMap<any>('tl_room')
+  const yRecords = useMap<any>('tl_room', {observe: 'none'})
 
   useEffect(() => {
     const unsubs: (() => void)[] = []

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -139,44 +139,50 @@ function useRedraw() {
   return useCallback(() => setRedraw((x) => x + 1), [setRedraw])
 }
 
-export function useMap<T>(name: string): Y.Map<T> {
+export type ObserverKind = 'deep' | 'shallow' | 'none'
+
+export type ObjectOptions = {
+  observe?: ObserverKind
+}
+
+export function useMap<T>(name: string, objectOptions?: ObjectOptions): Y.Map<T> {
   const doc = useYDoc()
   const map = useMemo(() => doc.getMap<T>(name), [doc, name])
-  useObserve(map)
+  useObserve(map, objectOptions?.observe || 'deep')
 
   return map
 }
 
-export function useArray<T>(name: string): Y.Array<T> {
+export function useArray<T>(name: string, objectOptions?: ObjectOptions): Y.Array<T> {
   const doc = useYDoc()
   const array = useMemo(() => doc.getArray<T>(name), [doc, name])
-  useObserve(array)
+  useObserve(array, objectOptions?.observe || 'deep')
 
   return array
 }
 
-export function useText(name: string): Y.Text {
+export function useText(name: string, observerKind?: ObjectOptions): Y.Text {
   const doc = useYDoc()
   const text = useMemo(() => doc.getText(name), [doc, name])
-  useObserve(text)
+  useObserve(text, observerKind?.observe || 'deep')
 
   return text
 }
 
-function useObserve(object: Y.AbstractType<any>, deep = true) {
+function useObserve(object: Y.AbstractType<any>, kind: ObserverKind) {
   const redraw = useRedraw()
 
   useEffect(() => {
-    if (deep) {
+    if (kind === 'deep') {
       object.observeDeep(redraw)
-    } else {
+    } else if (kind === 'shallow') {
       object.observe(redraw)
     }
 
     return () => {
-      if (deep) {
+      if (kind === 'deep') {
         object.unobserveDeep(redraw)
-      } else {
+      } else if (kind === 'shallow') {
         object.unobserve(redraw)
       }
     }


### PR DESCRIPTION
Previously, the `use{Map,Array,Text}` hooks accepted a `deep` parameter, allowing them to toggle between shallow listen and a deep listen. When dealing with third-party components that handle their own listeners, we usually don't want to listen at all.

This replaces the `deep` binary with a string value of `deep` / `shallow` / `none`. It also uses an object for configuration rather than a positional argument, which is good for readability (`useMap('foo', 'none')` gives no hint about what `none` means; `useMap('foo', {observe: 'none'})` does)