### PR TITLE
Set crate resolver

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
+
 members = [
     "y-sweet",
     "y-sweet-core",


### PR DESCRIPTION
This silences a warning that appears with the latest version of `cargo`:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```