### PR TITLE
Stricter action rules

### DIFF
--- a/.github/workflows/check-ts.yml
+++ b/.github/workflows/check-ts.yml
@@ -9,7 +9,7 @@ on:
       - "js-pkg/**"
 
 jobs:
-  prettier-check:
+  check-ts-format:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code

--- a/.github/workflows/check-ts.yml
+++ b/.github/workflows/check-ts.yml
@@ -1,10 +1,12 @@
 name: Check TypeScript code
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths:
+      - "examples/**"
+      - "tests/**"
+      - "js-pkg/**"
 
 jobs:
   prettier-check:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,7 +6,7 @@ on:
 
 name: Clippy check
 jobs:
-  clippy_check:
+  check-rust-clippy:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,8 @@
 on:
   pull_request:
     branches: [ "*" ]
+    paths:
+      - "crates/**"
 
 name: Clippy check
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  integration-test:
     runs-on: ubuntu-latest-16-cores
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,12 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths:
+      - "tests/**"
+      - "crates/**"
+      - "js-pkg/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,7 +7,7 @@ on:
       - "crates/**"
 
 jobs:
-  check_format:
+  check-rust-format:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -3,6 +3,8 @@ name: Rustfmt
 on:
   pull_request:
     branches: [ "*" ]
+    paths:
+      - "crates/**"
 
 jobs:
   check_format:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -3,13 +3,15 @@ name: Staging Deploy
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "crates/**"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     defaults:
       run:
         working-directory: ./crates/y-sweet-worker

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  staging-deploy:
     runs-on: ubuntu-latest-16-cores
     defaults:
       run:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,17 +1,17 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths:
+      - "crates/**"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     defaults:
       run:
         working-directory: ./crates

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,3 +27,4 @@ jobs:
 
     - name: Run unit tests
       run: cargo test --verbose
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  unit-test:
     runs-on: ubuntu-latest-16-cores
     defaults:
       run:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,4 +27,3 @@ jobs:
 
     - name: Run unit tests
       run: cargo test --verbose
-


### PR DESCRIPTION
Now that we have a lot of actions, PRs are a bit noisy. This restricts actions to only run when they matter.

I have also bumped a few workflows to run on beefier machines to reduce waiting time.

This also removes some tests from `push` and only runs them on `pull_request`. Rather than reactively checking tests _after_ a merge, we should ensure that tests pass _before_ a merge and require that the code be merged/rebase into the PR before it is merged. Currently we do this implicitly, but renaming the jobs so that they are unique should allow us to enforce this via GitHub as well.