### PR TITLE
Enlarge debugger console link

### DIFF
--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -26,7 +26,9 @@ export function useYDoc(options?: YDocOptions): Y.Doc {
 
   useEffect(() => {
     if (!options?.hideDebuggerLink && yjsCtx) {
-      console.log('Y-Sweet Debugger', debuggerUrl(yjsCtx.clientToken))
+      const url = debuggerUrl(yjsCtx.clientToken)
+      console.log(`%cOpen in Y-Sweet Debugger ⮕ ${url}`, 'font-size: 2em; display: block; padding: 15px;')
+      console.log('%cTo hide this message, pass { hideDebuggerLink: true } to useYDoc', 'font-style: italic;')
     }
   }, [options?.hideDebuggerLink, yjsCtx])
 

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -27,8 +27,14 @@ export function useYDoc(options?: YDocOptions): Y.Doc {
   useEffect(() => {
     if (!options?.hideDebuggerLink && yjsCtx) {
       const url = debuggerUrl(yjsCtx.clientToken)
-      console.log(`%cOpen in Y-Sweet Debugger ⮕ ${url}`, 'font-size: 2em; display: block; padding: 15px;')
-      console.log('%cTo hide this message, pass { hideDebuggerLink: true } to useYDoc', 'font-style: italic;')
+      console.log(
+        `%cOpen in Y-Sweet Debugger ⮕ ${url}`,
+        'font-size: 2em; display: block; padding: 15px;',
+      )
+      console.log(
+        '%cTo hide this message, pass { hideDebuggerLink: true } to useYDoc',
+        'font-style: italic;',
+      )
     }
   }, [options?.hideDebuggerLink, yjsCtx])
 

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -29,10 +29,10 @@ export function useYDoc(options?: YDocOptions): Y.Doc {
       const url = debuggerUrl(yjsCtx.clientToken)
       console.log(
         `%cOpen in Y-Sweet Debugger ⮕ ${url}`,
-        'font-size: 2em; display: block; padding: 15px;',
+        'font-size: 1.5em; display: block; padding: 10px;',
       )
       console.log(
-        '%cTo hide this message, pass { hideDebuggerLink: true } to useYDoc',
+        '%cTo hide the debugger link, pass { hideDebuggerLink: true } to useYDoc',
         'font-style: italic;',
       )
     }

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -28,7 +28,7 @@ export function useYDoc(options?: YDocOptions): Y.Doc {
     if (!options?.hideDebuggerLink && yjsCtx) {
       const url = debuggerUrl(yjsCtx.clientToken)
       console.log(
-        `%cOpen in Y-Sweet Debugger ⮕ ${url}`,
+        `%cOpen this in Y-Sweet Debugger ⮕ ${url}`,
         'font-size: 1.5em; display: block; padding: 10px;',
       )
       console.log(


### PR DESCRIPTION
This makes it easier to find the debugger link, and also provides instructions for disabling it in prod.

Before:

![image](https://github.com/drifting-in-space/y-sweet/assets/46173/60fcbfac-5e70-4b8b-9f0b-647460629827)

After:

![image](https://github.com/drifting-in-space/y-sweet/assets/46173/2e4e7863-c6ab-42fd-b1e6-a9c5f51235e4)
