### PR TITLE
Use provider in tests

### DIFF
--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -9,6 +9,8 @@ import { ClientToken } from '@y-sweet/sdk'
 import { createYjsProvider } from './yjs-provider'
 import { encodeClientToken } from '@y-sweet/sdk'
 
+export { createYjsProvider }
+
 type YjsContextType = {
   doc: Y.Doc
   provider: WebsocketProvider

--- a/package-lock.json
+++ b/package-lock.json
@@ -11437,6 +11437,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@y-sweet/react": "0.0.7",
         "@y-sweet/sdk": "0.0.7"
       },
       "devDependencies": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -20,6 +20,7 @@
         "yjs": "file:../node_modules/yjs"
     },
     "dependencies": {
-        "@y-sweet/sdk": "0.0.7"
+        "@y-sweet/sdk": "0.0.7",
+        "@y-sweet/react": "0.0.7"
     }
 }

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -1,5 +1,6 @@
 import { WebsocketProvider } from 'y-websocket'
 import { DocumentManager } from '@y-sweet/sdk'
+import { createYjsProvider } from '@y-sweet/react'
 import { WebSocket } from 'ws'
 import * as Y from 'yjs'
 import { Server, ServerConfiguration } from './server'
@@ -70,11 +71,7 @@ describe.each(CONFIGURATIONS)(
       }
 
       const doc = new Y.Doc()
-      const params = key.token ? { token: key.token } : undefined
-      const provider = new WebsocketProvider(key.url, key.doc, doc, {
-        params,
-        WebSocketPolyfill: require('ws'),
-      })
+      const provider = createYjsProvider(doc, key, { WebSocketPolyfill: require('ws') })
 
       await new Promise((resolve, reject) => {
         provider.on('synced', resolve)


### PR DESCRIPTION
- Exports `createYjsProvider` from `@y-sweet/react`
- Uses it in tests instead of implementing the same behavior.