### PR TITLE
optionally read server settings from env variables

### DIFF
--- a/crates/y-sweet/Cargo.toml
+++ b/crates/y-sweet/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/drifting-in-space/y-sweet"
 anyhow = "1.0.72"
 async-trait = "0.1.71"
 axum = { version = "0.6.19", features = ["ws", "headers"] }
-clap = { version = "4.3.12", features = ["derive"] }
+clap = { version = "4.3.12", features = ["derive", "env"] }
 colored = "2.0.4"
 dashmap = "5.5.0"
 futures = "0.3.28"

--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -37,19 +37,20 @@ struct Opts {
 #[derive(Subcommand)]
 enum ServSubcommand {
     Serve {
+        #[clap(env = "Y_SWEE_STORE")]
         store: Option<String>,
 
-        #[clap(long, default_value = "8080")]
+        #[clap(long, default_value = "8080", env = "Y_SWEET_PORT")]
         port: u16,
-        #[clap(long)]
+        #[clap(long, env = "Y_SWEET_HOST")]
         host: Option<IpAddr>,
-        #[clap(long, default_value = "10")]
+        #[clap(long, default_value = "10", env = "Y_SWEET_CHECKPOINT_FREQ_SECONDS")]
         checkpoint_freq_seconds: u64,
 
-        #[clap(long)]
+        #[clap(long, env = "Y_SWEET_AUTH")]
         auth: Option<String>,
 
-        #[clap(long)]
+        #[clap(long, env = "Y_SWEET_URL_PREFIX")]
         url_prefix: Option<Url>,
 
         #[clap(long)]


### PR DESCRIPTION
Clap can read Args from env variables, which is better than having them as command line parameters and is optional anyway