### PR TITLE
Fixes reading store from environment variable

### DIFF
--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -37,7 +37,6 @@ struct Opts {
 #[derive(Subcommand)]
 enum ServSubcommand {
     Serve {
-        #[clap(env = "Y_SWEE_STORE")]
         store: Option<String>,
 
         #[clap(long, default_value = "8080", env = "Y_SWEET_PORT")]
@@ -161,6 +160,8 @@ async fn main() -> Result<()> {
 
             let store = if let Some(store) = store {
                 Some(get_store_from_opts(store)?)
+            } else if let Ok(store) = std::env::var("Y_SWEET_STORE") {
+                Some(get_store_from_opts(&store)?)
             } else {
                 tracing::warn!("No store set. Documents will be stored in memory only.");
                 None


### PR DESCRIPTION
sorry I didn't test this before the previous PR. I can confirm now that this state allows setting all values with environment variables