### PR TITLE
Rename WebSocketProvider to YSweetProvider

### DIFF
--- a/crates/y-sweet/src/main.rs
+++ b/crates/y-sweet/src/main.rs
@@ -37,7 +37,7 @@ struct Opts {
 #[derive(Subcommand)]
 enum ServSubcommand {
     Serve {
-        #[clap(env = "Y_SWEE_STORE")]
+        #[clap(env = "Y_SWEET_STORE")]
         store: Option<String>,
 
         #[clap(long, default_value = "8080", env = "Y_SWEET_PORT")]

--- a/js-pkg/client/src/main.ts
+++ b/js-pkg/client/src/main.ts
@@ -1,11 +1,11 @@
-import { WebsocketProvider, type WebsocketProviderParams } from './websocket'
+import { YSweetProvider, type WebsocketProviderParams } from './provider'
 import * as Y from 'yjs'
 import { ClientToken } from '@y-sweet/sdk'
 
-export { WebsocketProvider, WebsocketProviderParams }
+export { YSweetProvider, WebsocketProviderParams }
 
 /**
- * Given a {@link ClientToken}, create a {@link WebsocketProvider} for it.
+ * Given a {@link ClientToken}, create a {@link YSweetProvider} for it.
  *
  * @param doc
  * @param clientToken
@@ -16,10 +16,10 @@ export function createYjsProvider(
   doc: Y.Doc,
   clientToken: ClientToken,
   extraOptions: Partial<WebsocketProviderParams> = {},
-): WebsocketProvider {
+): YSweetProvider {
   const params = clientToken.token ? { token: clientToken.token } : undefined
 
-  const provider = new WebsocketProvider(clientToken.url, clientToken.doc, doc, {
+  const provider = new YSweetProvider(clientToken.url, clientToken.doc, doc, {
     params,
     ...extraOptions,
   })

--- a/js-pkg/client/src/main.ts
+++ b/js-pkg/client/src/main.ts
@@ -1,8 +1,8 @@
-import { YSweetProvider, type WebsocketProviderParams } from './provider'
+import { YSweetProvider, type YSweetProviderParams } from './provider'
 import * as Y from 'yjs'
 import { ClientToken } from '@y-sweet/sdk'
 
-export { YSweetProvider, WebsocketProviderParams }
+export { YSweetProvider, YSweetProviderParams as WebsocketProviderParams, YSweetProviderParams }
 
 /**
  * Given a {@link ClientToken}, create a {@link YSweetProvider} for it.
@@ -15,7 +15,7 @@ export { YSweetProvider, WebsocketProviderParams }
 export function createYjsProvider(
   doc: Y.Doc,
   clientToken: ClientToken,
-  extraOptions: Partial<WebsocketProviderParams> = {},
+  extraOptions: Partial<YSweetProviderParams> = {},
 ): YSweetProvider {
   const params = clientToken.token ? { token: clientToken.token } : undefined
 

--- a/js-pkg/client/src/main.ts
+++ b/js-pkg/client/src/main.ts
@@ -2,7 +2,7 @@ import { YSweetProvider, type YSweetProviderParams } from './provider'
 import * as Y from 'yjs'
 import { ClientToken } from '@y-sweet/sdk'
 
-export { YSweetProvider, YSweetProviderParams as WebsocketProviderParams, YSweetProviderParams }
+export { YSweetProvider, YSweetProviderParams }
 
 /**
  * Given a {@link ClientToken}, create a {@link YSweetProvider} for it.

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -196,7 +196,7 @@ type WebSocketPolyfillType = {
   readonly OPEN: number
 }
 
-export type WebsocketProviderParams = {
+export type YSweetProviderParams = {
   connect?: boolean
   awareness?: awarenessProtocol.Awareness
   params?: {
@@ -215,9 +215,9 @@ export type WebsocketProviderParams = {
  *
  * @example
  *   import * as Y from 'yjs'
- *   import { WebsocketProvider } from 'y-websocket'
+ *   import { YSweetProvider } from 'y-websocket'
  *   const doc = new Y.Doc()
- *   const provider = new WebsocketProvider('http://localhost:1234', 'my-document-name', doc)
+ *   const provider = new YSweetProvider('http://localhost:1234', 'my-document-name', doc)
  *
  * @extends {Observable<string>}
  */
@@ -271,7 +271,7 @@ export class YSweetProvider extends Observable<string> {
       resyncInterval = -1,
       maxBackoffTime = 2500,
       disableBc = false,
-    }: WebsocketProviderParams = {},
+    }: YSweetProviderParams = {},
   ) {
     super()
     // ensure that url is always ends with /

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -214,11 +214,10 @@ export type YSweetProviderParams = {
  * creates a websocket connection to http://localhost:1234/my-document-name
  *
  * @example
- *   import * as Y from 'yjs'
- *   import { YSweetProvider } from 'y-websocket'
- *   const doc = new Y.Doc()
- *   const provider = new YSweetProvider('http://localhost:1234', 'my-document-name', doc)
- *
+ * import * as Y from 'yjs'
+ * import { YSweetProvider } from 'y-websocket'
+ * const doc = new Y.Doc()
+ * const provider = new YSweetProvider('http://localhost:1234', 'my-document-name', doc)
  * @extends {Observable<string>}
  */
 export class YSweetProvider extends Observable<string> {

--- a/js-pkg/client/src/provider.ts
+++ b/js-pkg/client/src/provider.ts
@@ -24,7 +24,7 @@ export const messageAuth = 2
 export type HandlerFunction = (
   encoder: encoding.Encoder,
   decoder: decoding.Decoder,
-  provider: WebsocketProvider,
+  provider: YSweetProvider,
   emitSynced: boolean,
   messageType: number,
 ) => void
@@ -73,11 +73,11 @@ messageHandlers[messageAuth] = (_encoder, decoder, provider, _emitSynced, _messa
 // @todo - this should depend on awareness.outdatedTime
 const messageReconnectTimeout = 30000
 
-const permissionDeniedHandler = (provider: WebsocketProvider, reason: string) =>
+const permissionDeniedHandler = (provider: YSweetProvider, reason: string) =>
   console.warn(`Permission denied to access ${provider.url}.\n${reason}`)
 
 const readMessage = (
-  provider: WebsocketProvider,
+  provider: YSweetProvider,
   buf: Uint8Array,
   emitSynced: boolean,
 ): encoding.Encoder => {
@@ -93,7 +93,7 @@ const readMessage = (
   return encoder
 }
 
-const setupWS = (provider: WebsocketProvider) => {
+const setupWS = (provider: YSweetProvider) => {
   if (provider.shouldConnect && provider.ws === null) {
     const websocket = new provider._WS(provider.url)
     websocket.binaryType = 'arraybuffer'
@@ -177,7 +177,7 @@ const setupWS = (provider: WebsocketProvider) => {
   }
 }
 
-const broadcastMessage = (provider: WebsocketProvider, buf: ArrayBuffer) => {
+const broadcastMessage = (provider: YSweetProvider, buf: ArrayBuffer) => {
   const ws = provider.ws
   if (provider.wsconnected && ws && ws.readyState === ws.OPEN) {
     ws.send(buf)
@@ -221,7 +221,7 @@ export type WebsocketProviderParams = {
  *
  * @extends {Observable<string>}
  */
-export class WebsocketProvider extends Observable<string> {
+export class YSweetProvider extends Observable<string> {
   maxBackoffTime: number
   bcChannel: string
   url: string

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import { WebsocketProvider, WebsocketProviderParams, createYjsProvider } from '@y-sweet/client'
+import { YSweetProvider, WebsocketProviderParams, createYjsProvider } from '@y-sweet/client'
 import { ClientToken, encodeClientToken } from '@y-sweet/sdk'
 import type { ReactNode } from 'react'
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { Awareness } from 'y-protocols/awareness'
 import * as Y from 'yjs'
-export { createYjsProvider, WebsocketProvider, type WebsocketProviderParams }
+export { createYjsProvider, YSweetProvider, YSweetProvider as WebsocketProvider, type WebsocketProviderParams }
 
 type YjsContextType = {
   doc: Y.Doc
-  provider: WebsocketProvider
+  provider: YSweetProvider
   clientToken: ClientToken
 }
 
@@ -80,7 +80,7 @@ export function useYSweetDebugUrl(): string {
  *
  * @returns The Yjs WebsocketProvider instance.
  */
-export function useYjsProvider(): WebsocketProvider {
+export function useYjsProvider(): YSweetProvider {
   const yjsCtx = useContext(YjsContext)
   if (!yjsCtx) {
     throw new Error('Yjs hooks must be used within a YDocProvider')

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -9,9 +9,7 @@ import * as Y from 'yjs'
 export {
   createYjsProvider,
   YSweetProvider,
-  YSweetProvider as WebsocketProvider,
   type YSweetProviderParams,
-  type YSweetProviderParams as WebsocketProviderParams,
 }
 
 type YjsContextType = {

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -6,11 +6,7 @@ import type { ReactNode } from 'react'
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { Awareness } from 'y-protocols/awareness'
 import * as Y from 'yjs'
-export {
-  createYjsProvider,
-  YSweetProvider,
-  type YSweetProviderParams,
-}
+export { createYjsProvider, YSweetProvider, type YSweetProviderParams }
 
 type YjsContextType = {
   doc: Y.Doc

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -1,12 +1,18 @@
 'use client'
 
-import { YSweetProvider, WebsocketProviderParams, createYjsProvider } from '@y-sweet/client'
+import { YSweetProvider, YSweetProviderParams, createYjsProvider } from '@y-sweet/client'
 import { ClientToken, encodeClientToken } from '@y-sweet/sdk'
 import type { ReactNode } from 'react'
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { Awareness } from 'y-protocols/awareness'
 import * as Y from 'yjs'
-export { createYjsProvider, YSweetProvider, YSweetProvider as WebsocketProvider, type WebsocketProviderParams }
+export {
+  createYjsProvider,
+  YSweetProvider,
+  YSweetProvider as WebsocketProvider,
+  type YSweetProviderParams,
+  type YSweetProviderParams as WebsocketProviderParams,
+}
 
 type YjsContextType = {
   doc: Y.Doc
@@ -73,12 +79,12 @@ export function useYSweetDebugUrl(): string {
 }
 
 /**
- * React hook for obtaining the Yjs WebsocketProvider instance from the current context.
+ * React hook for obtaining the YSweetProvider instance from the current context.
  *
  * This is useful for integrating components that expect a direct reference
  * to the provider.
  *
- * @returns The Yjs WebsocketProvider instance.
+ * @returns The YSweetProvider instance.
  */
 export function useYjsProvider(): YSweetProvider {
   const yjsCtx = useContext(YjsContext)

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeAll, afterAll } from 'vitest'
 import { DocumentManager } from '@y-sweet/sdk'
-import { createYjsProvider as createYjsProvider_, WebsocketProviderParams } from '@y-sweet/react'
+import { createYjsProvider as createYjsProvider_, YSweetProviderParams } from '@y-sweet/react'
 import { WebSocket } from 'ws'
 import * as Y from 'yjs'
 import { Server, ServerConfiguration } from './server'
@@ -13,7 +13,7 @@ import { Server, ServerConfiguration } from './server'
 function createYjsProvider(
   doc: Y.Doc,
   clientToken: { url: string; doc: string; token?: string },
-  extraOptions: WebsocketProviderParams,
+  extraOptions: YSweetProviderParams,
 ) {
   extraOptions = {
     WebSocketPolyfill: require('ws'),


### PR DESCRIPTION
This avoids the name clash with y-websocket, from which the provider was forked.