### PR TITLE
Make Minio tests work on Mac

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",

--- a/crates/y-sweet-worker/.gitignore
+++ b/crates/y-sweet-worker/.gitignore
@@ -2,3 +2,4 @@ build
 data
 node_modules
 target
+.wrangler

--- a/crates/y-sweet-worker/package-lock.json
+++ b/crates/y-sweet-worker/package-lock.json
@@ -7,7 +7,7 @@
 		"": {
 			"version": "0.0.0",
 			"devDependencies": {
-				"wrangler": "^3.14.0"
+				"wrangler": "^3.19.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -20,9 +20,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20231016.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231016.0.tgz",
-			"integrity": "sha512-rPAnF8Q25+eHEsAopihWeftPW/P0QapY9d7qaUmtOXztWdd6YPQ7JuiWVj4Nvjphge1BleehxAbo4I3Z4L2H1g==",
+			"version": "1.20231030.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20231030.0.tgz",
+			"integrity": "sha512-J4PQ9utPxLya9yHdMMx3AZeC5M/6FxcoYw6jo9jbDDFTy+a4Gslqf4Im9We3aeOEdPXa3tgQHVQOSelJSZLhIw==",
 			"cpu": [
 				"x64"
 			],
@@ -36,9 +36,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20231016.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231016.0.tgz",
-			"integrity": "sha512-MvydDdiLXt+jy57vrVZ2lU6EQwCdpieyZoN8uBXSWzfG3zR/6dxU1+okvPQPlHN0jtlufqPeHrpJyAqqgLHUKA==",
+			"version": "1.20231030.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20231030.0.tgz",
+			"integrity": "sha512-WSJJjm11Del4hSneiNB7wTXGtBXI4QMCH9l5qf4iT5PAW8cESGcCmdHtWDWDtGAAGcvmLT04KNvmum92vRKKQQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -52,9 +52,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20231016.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231016.0.tgz",
-			"integrity": "sha512-y6Sj37yTzM8QbAghG9LRqoSBrsREnQz8NkcmpjSxeK6KMc2g0L5A/OemCdugNlIiv+zRv9BYX1aosaoxY5JbeQ==",
+			"version": "1.20231030.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20231030.0.tgz",
+			"integrity": "sha512-2HUeRTvoCC17fxE0qdBeR7J9dO8j4A8ZbdcvY8pZxdk+zERU6+N03RTbk/dQMU488PwiDvcC3zZqS4gwLfVT8g==",
 			"cpu": [
 				"x64"
 			],
@@ -68,9 +68,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20231016.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231016.0.tgz",
-			"integrity": "sha512-LqMIRUHD1YeRg2TPIfIQEhapSKMFSq561RypvJoXZvTwSbaROxGdW6Ku+PvButqTkEvuAtfzN/kGje7fvfQMHg==",
+			"version": "1.20231030.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20231030.0.tgz",
+			"integrity": "sha512-4/GK5zHh+9JbUI6Z5xTCM0ZmpKKHk7vu9thmHjUxtz+o8Ne9DoD7DlDvXQWgMF6XGaTubDWyp3ttn+Qv8jDFuQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -84,9 +84,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20231016.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231016.0.tgz",
-			"integrity": "sha512-96ojBwIHyiUAbsWlzBqo9P/cvH8xUh8SuBboFXtwAeXcJ6/urwKN2AqPa/QzOGUTCdsurWYiieARHT5WWWPhKw==",
+			"version": "1.20231030.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20231030.0.tgz",
+			"integrity": "sha512-fb/Jgj8Yqy3PO1jLhk7mTrHMkR8jklpbQFud6rL/aMAn5d6MQbaSrYOCjzkKGp0Zng8D2LIzSl+Fc0C9Sggxjg==",
 			"cpu": [
 				"x64"
 			],
@@ -474,18 +474,18 @@
 			}
 		},
 		"node_modules/@fastify/busboy": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-			"integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+			"integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
 			"dev": true,
 			"engines": {
 				"node": ">=14"
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+			"version": "8.11.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -495,9 +495,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
+			"integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
@@ -812,9 +812,9 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "3.20231016.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231016.0.tgz",
-			"integrity": "sha512-AmlqI89zsnBJfC+nKKZdCB/fuu0q/br24Kqt9NZwcT6yJEpO5NytNKfjl6nJROHROwuJSRQR1T3yopCtG1/0DA==",
+			"version": "3.20231030.3",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20231030.3.tgz",
+			"integrity": "sha512-lquHSh0XiO8uoWDujOLHtDS9mkUTJTc5C5amiQ6A++5y0f+DWiMqbDBvvwjlYf4Dvqk6ChFya9dztk7fg2ZVxA==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -825,10 +825,13 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.22.1",
-				"workerd": "1.20231016.0",
+				"workerd": "1.20231030.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
+			},
+			"bin": {
+				"miniflare": "bootstrap.js"
 			},
 			"engines": {
 				"node": ">=16.13"
@@ -919,6 +922,15 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/resolve.exports": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/rollup-plugin-inject": {
@@ -1028,9 +1040,9 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "5.26.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.26.4.tgz",
-			"integrity": "sha512-OG+QOf0fTLtazL9P9X7yqWxQ+Z0395Wk6DSkyTxtaq3wQEjIroVe7Y4asCX/vcCxYpNGMnwz8F0qbRYUoaQVMw==",
+			"version": "5.28.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+			"integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
 			"dev": true,
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
@@ -1040,9 +1052,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20231016.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231016.0.tgz",
-			"integrity": "sha512-v2GDb5XitSqgub/xm7EWHVAlAK4snxQu3itdMQxXstGtUG9hl79fQbXS/8fNFbmms2R2bAxUwSv47q8k5T5Erw==",
+			"version": "1.20231030.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20231030.0.tgz",
+			"integrity": "sha512-+FSW+d31f8RrjHanFf/R9A+Z0csf3OtsvzdPmAKuwuZm/5HrBv83cvG9fFeTxl7/nI6irUUXIRF9xcj/NomQzQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1052,17 +1064,17 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20231016.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20231016.0",
-				"@cloudflare/workerd-linux-64": "1.20231016.0",
-				"@cloudflare/workerd-linux-arm64": "1.20231016.0",
-				"@cloudflare/workerd-windows-64": "1.20231016.0"
+				"@cloudflare/workerd-darwin-64": "1.20231030.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20231030.0",
+				"@cloudflare/workerd-linux-64": "1.20231030.0",
+				"@cloudflare/workerd-linux-arm64": "1.20231030.0",
+				"@cloudflare/workerd-windows-64": "1.20231030.0"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.14.0.tgz",
-			"integrity": "sha512-4vzw11yG1/KXpYKbumvRJ61Iyhm/yKXb/ayOw/2xiIRdKdpsfN9/796d2l525+CDaGwZWswpLENe6ZMS0p/Ghg==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.19.0.tgz",
+			"integrity": "sha512-pY7xWqkQn6DJ+1vz9YHz2pCftEmK+JCTj9sqnucp0NZnlUiILDmBWegsjjCLZycgfiA62J213N7NvjLPr2LB8w==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "^0.2.0",
@@ -1071,9 +1083,10 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.17.19",
-				"miniflare": "3.20231016.0",
+				"miniflare": "3.20231030.3",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
+				"resolve.exports": "^2.0.2",
 				"selfsigned": "^2.0.1",
 				"source-map": "0.6.1",
 				"source-map-support": "0.5.21",
@@ -1084,7 +1097,7 @@
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=16.13.0"
+				"node": ">=16.17.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -1118,9 +1131,9 @@
 			"dev": true
 		},
 		"node_modules/youch": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.2.tgz",
-			"integrity": "sha512-9cwz/z7abtcHOIuH45nzmUFCZbyJA1nLqlirKvyNRx4wDMhqsBaifAJzBej7L4fsVPjFxYq3NK3GAcfvZsydFw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.3.tgz",
+			"integrity": "sha512-qSFXUk3UZBLfggAW3dJKg0BMblG5biqSF8M34E06o5CSsZtH92u9Hqmj2RzGiHDi64fhe83+4tENFP2DB6t6ZA==",
 			"dev": true,
 			"dependencies": {
 				"cookie": "^0.5.0",

--- a/crates/y-sweet-worker/package.json
+++ b/crates/y-sweet-worker/package.json
@@ -6,6 +6,6 @@
 		"dev": "wrangler dev --persist-to ./data --port 8080"
 	},
 	"devDependencies": {
-		"wrangler": "^3.14.0"
+		"wrangler": "^3.19.0"
 	}
 }

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -27,9 +27,14 @@ function createYjsProvider(
 const CONFIGURATIONS: ServerConfiguration[] = [
   { useAuth: false, server: 'native' },
   { useAuth: true, server: 'native' },
-  // { useAuth: false, server: 'worker' },
-  // { useAuth: true, server: 'worker' },
 ]
+
+if (process.env.GITHUB_ACTIONS !== 'true') {
+  CONFIGURATIONS.push(
+    { useAuth: false, server: 'worker' },
+    { useAuth: true, server: 'worker' },
+  )
+}
 
 let S3_ACCESS_KEY_ID = process.env.Y_SWEET_S3_ACCESS_KEY_ID
 let S3_SECRET_KEY = process.env.Y_SWEET_S3_SECRET_KEY

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -27,8 +27,8 @@ function createYjsProvider(
 const CONFIGURATIONS: ServerConfiguration[] = [
   { useAuth: false, server: 'native' },
   { useAuth: true, server: 'native' },
-  { useAuth: false, server: 'worker' },
-  { useAuth: true, server: 'worker' },
+  // { useAuth: false, server: 'worker' },
+  // { useAuth: true, server: 'worker' },
 ]
 
 let S3_ACCESS_KEY_ID = process.env.Y_SWEET_S3_ACCESS_KEY_ID
@@ -40,7 +40,7 @@ let S3_BUCKET_NAME = process.env.Y_SWEET_S3_BUCKET_NAME
 if (S3_ACCESS_KEY_ID && S3_REGION && S3_SECRET_KEY && S3_BUCKET_PREFIX && S3_BUCKET_NAME) {
   CONFIGURATIONS.push({
     useAuth: true,
-    server: 'worker',
+    server: 'native',
     s3: {
       bucket_name: S3_BUCKET_NAME,
       bucket_prefix: S3_BUCKET_PREFIX,

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -30,10 +30,7 @@ const CONFIGURATIONS: ServerConfiguration[] = [
 ]
 
 if (process.env.GITHUB_ACTIONS !== 'true') {
-  CONFIGURATIONS.push(
-    { useAuth: false, server: 'worker' },
-    { useAuth: true, server: 'worker' },
-  )
+  CONFIGURATIONS.push({ useAuth: false, server: 'worker' }, { useAuth: true, server: 'worker' })
 }
 
 let S3_ACCESS_KEY_ID = process.env.Y_SWEET_S3_ACCESS_KEY_ID

--- a/tests/src/server.ts
+++ b/tests/src/server.ts
@@ -111,7 +111,7 @@ export class Server {
         vars['BUCKET_KIND'] = 'S3'
       }
 
-      let command = `npx --yes wrangler dev --persist-to ${this.dataDir} --port ${this.port} --env test`
+      let command = `npx --yes wrangler dev --persist-to ${this.dataDir} --port ${this.port} --env test --live-reload false`
 
       if (Object.entries(vars).length > 0) {
         command += ' --var'

--- a/tests/test-with-minio.sh
+++ b/tests/test-with-minio.sh
@@ -5,17 +5,19 @@ set -e
 docker rm -f minio
 docker rm -f minio-mc
 
-docker run -d --network host --name minio \
+docker run -d --name minio \
+  -p 9000:9000 \
   quay.io/minio/minio server /data --console-address ":9001"
 
+# Start a container with a sleep loop to run the minio client.
 docker run -d \
-  --network host \
   --name minio-mc \
+  --add-host "host.docker.internal:host-gateway" \
   --entrypoint=/bin/sh minio/mc \
   -c 'while true; do sleep 1000; done'
 
 docker exec minio-mc mc \
-  alias set mycloud http://localhost:9000 minioadmin minioadmin
+  alias set mycloud http://host.docker.internal:9000 minioadmin minioadmin
 
 docker exec minio-mc mc \
   mb mycloud/ysweet-testing-y-sweet-data


### PR DESCRIPTION
This PR does some yak shaving from debugging some S3 integration test stuff:
- Makes Minio tests work under Docker on Mac (by using a host binding instead of the host network)
- Updates the version of wrangler
- Updates some cargo dependencies
- Disables `worker` tests in CI/CD after determining that the flakiness is coming from `workerd` on Linux.