### PR TITLE
Fix source links

### DIFF
--- a/js-pkg/gen-docs/src/main.ts
+++ b/js-pkg/gen-docs/src/main.ts
@@ -13,6 +13,7 @@ async function generateDocumentationForProject(
     json: tempFileName, // output file
     basePath,
     tsconfig: path.join(basePath, 'tsconfig.json'),
+    sourceLinkTemplate: 'https://github.com/drifting-in-space/y-sweet/blob/{gitRevision}/{path}#L{line}'
   })
 
   const project = await app.convert()

--- a/js-pkg/gen-docs/src/main.ts
+++ b/js-pkg/gen-docs/src/main.ts
@@ -13,7 +13,8 @@ async function generateDocumentationForProject(
     json: tempFileName, // output file
     basePath,
     tsconfig: path.join(basePath, 'tsconfig.json'),
-    sourceLinkTemplate: 'https://github.com/drifting-in-space/y-sweet/blob/{gitRevision}/{path}#L{line}'
+    sourceLinkTemplate:
+      'https://github.com/drifting-in-space/y-sweet/blob/{gitRevision}/{path}#L{line}',
   })
 
   const project = await app.convert()


### PR DESCRIPTION
Vercel seems to do something that breaks TypeDoc auto-detecting source links. This fixes that.

Currently, source references are text:

<img width="218" alt="image" src="https://github.com/drifting-in-space/y-sweet/assets/46173/dd5774bf-0852-4e41-8840-f9fef1ae1222">

This makes them clickable:

<img width="220" alt="image" src="https://github.com/drifting-in-space/y-sweet/assets/46173/3acd3cad-87bd-49c4-b0e8-e6ae2e2f510a">
