### PR TITLE
Move debugger functionality into vanilla JS library

### DIFF
--- a/js-pkg/client/src/main.ts
+++ b/js-pkg/client/src/main.ts
@@ -1,7 +1,6 @@
 import { YSweetProvider, type YSweetProviderParams } from './provider'
 import * as Y from 'yjs'
-import { ClientToken } from '@y-sweet/sdk'
-
+import { ClientToken, encodeClientToken } from '@y-sweet/sdk'
 export { YSweetProvider, YSweetProviderParams }
 
 /**
@@ -25,4 +24,15 @@ export function createYjsProvider(
   })
 
   return provider
+}
+
+/**
+ * Get a URL to open the Y-Sweet Debugger for the given client token.
+ *
+ * @param clientToken The client token to open the debugger for.
+ * @returns A debugger URL as a string.
+ */
+export function debuggerUrl(clientToken: ClientToken): string {
+  const payload = encodeClientToken(clientToken)
+  return `https://debugger.y-sweet.dev/?payload=${payload}`
 }

--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -1,12 +1,17 @@
 'use client'
 
-import { YSweetProvider, YSweetProviderParams, createYjsProvider } from '@y-sweet/client'
-import { ClientToken, encodeClientToken } from '@y-sweet/sdk'
+import {
+  YSweetProvider,
+  YSweetProviderParams,
+  createYjsProvider,
+  debuggerUrl,
+} from '@y-sweet/client'
+import { ClientToken } from '@y-sweet/sdk'
 import type { ReactNode } from 'react'
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { Awareness } from 'y-protocols/awareness'
 import * as Y from 'yjs'
-export { createYjsProvider, YSweetProvider, type YSweetProviderParams }
+export { createYjsProvider, YSweetProvider, debuggerUrl, type YSweetProviderParams }
 
 type YjsContextType = {
   doc: Y.Doc
@@ -46,17 +51,6 @@ export function useYDoc(options?: YDocOptions): Y.Doc {
     throw new Error('Yjs hooks must be used within a YDocProvider')
   }
   return yjsCtx.doc
-}
-
-/**
- * Get a URL to open the Y-Sweet Debugger for the given client token.
- *
- * @param clientToken The client token to open the debugger for.
- * @returns A debugger URL as a string.
- */
-export function debuggerUrl(clientToken: ClientToken): string {
-  const payload = encodeClientToken(clientToken)
-  return `https://debugger.y-sweet.dev/?payload=${payload}`
 }
 
 /**


### PR DESCRIPTION
@websiddu asked [on Discord](https://discord.com/channels/939641163265232947/939641163265232950/1188002703658459187) about how to get the debugger URL in the vanilla JS client. Currently the function that creates it is defined in the React client. This moves it over to the vanilla JS client library.

It is still re-exported from the React library in order to not break any existing code.