### PR TITLE
Fix arm64 linux builder and add to y-sweet npm package.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,8 @@ jobs:
     - name: Install musl-tools 
       run: sudo apt-get install -y musl-tools
 
+    - run: sudo apt-get install gcc-aarch64-linux-gnu
+
     - name: Build for Linux
       uses: actions-rs/cargo@v1
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,9 @@ jobs:
 
     - name: Build for Linux
       uses: actions-rs/cargo@v1
+      env:
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+        CC: aarch64-linux-gnu-gcc
       with:
         command: build
         args: --release --target aarch64-unknown-linux-musl --manifest-path=crates/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       version:
         description: 'Release Version'
         required: true
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - ".github/workflows/release.yml"
 
 jobs:
   build-macos-arm64:
@@ -125,6 +129,7 @@ jobs:
   release:
     needs: [build-linux, build-macos-arm64, build-macos-x64, build-windows]
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v2

--- a/js-pkg/server/package-lock.json
+++ b/js-pkg/server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "y-sweet",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "y-sweet",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {

--- a/js-pkg/server/package.json
+++ b/js-pkg/server/package.json
@@ -7,7 +7,7 @@
         "postinstall": "node src/install.js",
         "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
     },
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "npm wrapper for y-sweet server",
     "homepage": "https://github.com/drifting-in-space/y-sweet",
     "repository": {

--- a/js-pkg/server/src/get_binary.js
+++ b/js-pkg/server/src/get_binary.js
@@ -5,6 +5,7 @@ const VERSION = require('../package.json').version
 function getSuffix(os_type, os_arch) {
   if (os_type === 'Windows_NT' && os_arch === 'x64') return 'win-x64.exe.gz'
   if (os_type === 'Linux' && os_arch === 'x64') return 'linux-x64.gz'
+  if (os_type === 'Linux' && os_arch === 'arm64') return 'linux-arm64.gz'
   if (os_type === 'Darwin' && os_arch === 'x64') return 'macos-x64.gz'
   if (os_type === 'Darwin' && os_arch === 'arm64') return 'macos-arm64.gz'
 


### PR DESCRIPTION
Closes #206.

I've tested the binary it creates on an AWS arm64 instance and it worked.