### PR TITLE
Bump crate to v0.1.1

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "y-sweet-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/y-sweet-core/Cargo.toml
+++ b/crates/y-sweet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "y-sweet-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Sans-IO core of the y-sweet yjs CRDT server."
 license = "MIT"

--- a/crates/y-sweet/Cargo.toml
+++ b/crates/y-sweet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "y-sweet"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A standalone Yjs CRDT server with built-in persistence and auth."
 license = "MIT"


### PR DESCRIPTION
This creates a new patch release so that I can run the release pipeline to create a new set of binaries, which will now include a linux arm64 build (#206)