### PR TITLE
Support prefix path for R2 buckets

### DIFF
--- a/crates/y-sweet-worker/src/config.rs
+++ b/crates/y-sweet-worker/src/config.rs
@@ -105,7 +105,7 @@ impl TryFrom<&Env> for Configuration {
             auth_key_id: None,
             bucket: BUCKET.to_string(),
             s3_store_config: s3_config,
-            bucket_prefix: None,
+            bucket_prefix: env.var(S3_BUCKET_PREFIX).map(|s| s.to_string()).ok(),
             url_prefix: None,
             timeout_interval,
         })


### PR DESCRIPTION
Finally played around with Y-Sweet and it's really slick! Local testing was a breeze and it was super easy to deploy on Cloudflare Workers.

One area in which the R2 support doesn't seem to have parity with S3 (afaict) is in using a bucket prefix. This PR adds that — slightly awkwardly, as it reuses the `S3_BUCKET_PREFIX` environment variable even though it's not an S3 bucket. Happy to change the PR if you have a better way to do this!