### PR TITLE
fix npm install for some folks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13429,7 +13429,7 @@
         "typescript": "^5.1.6",
         "vitest": "^0.34.4",
         "ws": "^8.13.0",
-        "yjs": "file:../node_modules/yjs"
+        "yjs": "^13.6.7"
       }
     },
     "tests/node_modules/yjs": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "typescript": "^5.1.6",
     "vitest": "^0.34.4",
     "ws": "^8.13.0",
-    "yjs": "file:../node_modules/yjs"
+    "yjs": "^13.6.7"
   },
   "dependencies": {
     "@y-sweet/react": "0.1.0",


### PR DESCRIPTION
fixes #212 

It's strange, but I can't reduce this problem even when doing a fresh clone of the repo and then `npm install`ing in `examples/nextjs`. I wonder if different versions of npm run the install on workspaces in a different order so that in some cases the `node_modules` directory isn't in the root by the time the `tests` npm install runs? 

In any event, this PR should fix the problem.