### PR TITLE
Don't show multiple debugger links

### DIFF
--- a/js-pkg/react/src/main.tsx
+++ b/js-pkg/react/src/main.tsx
@@ -251,7 +251,7 @@ export type ObjectOptions = {
  * @returns
  */
 export function useMap<T>(name: string, objectOptions?: ObjectOptions): Y.Map<T> {
-  const doc = useYDoc()
+  const doc = useYDoc({ hideDebuggerLink: true })
   const map = useMemo(() => doc.getMap<T>(name), [doc, name])
   useObserve(map, objectOptions?.observe || 'deep')
 
@@ -275,7 +275,7 @@ export function useMap<T>(name: string, objectOptions?: ObjectOptions): Y.Map<T>
  * @returns
  */
 export function useArray<T>(name: string, objectOptions?: ObjectOptions): Y.Array<T> {
-  const doc = useYDoc()
+  const doc = useYDoc({ hideDebuggerLink: true })
   const array = useMemo(() => doc.getArray<T>(name), [doc, name])
   useObserve(array, objectOptions?.observe || 'deep')
 
@@ -298,7 +298,7 @@ export function useArray<T>(name: string, objectOptions?: ObjectOptions): Y.Arra
  * @returns
  */
 export function useText(name: string, observerKind?: ObjectOptions): Y.Text {
-  const doc = useYDoc()
+  const doc = useYDoc({ hideDebuggerLink: true })
   const text = useMemo(() => doc.getText(name), [doc, name])
   useObserve(text, observerKind?.observe || 'deep')
 


### PR DESCRIPTION
The `useMap` etc. family of hooks call `useDoc`. `useDoc` now displays the debugger link by default, but we only want that behavior when it is called directly. Otherwise, it is impossible to suppress the debugger link, and it is repeated multiple times. This fixes that.