### PR TITLE
Fix document creation race condition

### DIFF
--- a/crates/y-sweet-worker/src/durable_object.rs
+++ b/crates/y-sweet-worker/src/durable_object.rs
@@ -20,7 +20,7 @@ pub struct YServe {
 
 impl YServe {
     /// We need to lazily create the doc because the constructor is non-async.
-    pub async fn get_doc(&mut self, req: &Request, doc_id: &str) -> Result<&mut DocWithSyncKv> {
+    pub async fn get_doc(&mut self, req: &Request, doc_id: &str, create: bool) -> Result<&mut DocWithSyncKv> {
         if self.lazy_doc.is_none() {
             let mut context = ServerContext::from_request(req, &self.env).unwrap();
             #[allow(clippy::arc_with_non_send_sync)] // Arc required for compatibility with core.
@@ -44,6 +44,10 @@ impl YServe {
             })
             .await
             .unwrap();
+
+            if create {
+                doc.sync_kv().persist().await.unwrap();
+            }
 
             self.lazy_doc = Some(DocIdPair {
                 doc,
@@ -78,6 +82,7 @@ impl DurableObject for YServe {
         let req = ServerContext::reconstruct_request(&req)?;
 
         Router::with_data(self)
+            .post_async("/doc/:doc_id", handle_doc_create)
             .get_async("/doc/ws/:doc_id", websocket_connect)
             .run(req, env)
             .await
@@ -92,12 +97,19 @@ impl DurableObject for YServe {
     }
 }
 
+async fn handle_doc_create(req: Request, ctx: RouteContext<&mut YServe>) -> Result<Response> {
+    let doc_id = ctx.param("doc_id").unwrap().to_owned();
+    ctx.data.get_doc(&req, &doc_id, true).await.unwrap();
+
+    Response::ok("ok")
+}
+
 async fn websocket_connect(req: Request, ctx: RouteContext<&mut YServe>) -> Result<Response> {
     let WebSocketPair { client, server } = WebSocketPair::new()?;
     server.accept()?;
 
     let doc_id = ctx.param("doc_id").unwrap().to_owned();
-    let awareness = ctx.data.get_doc(&req, &doc_id).await.unwrap().awareness();
+    let awareness = ctx.data.get_doc(&req, &doc_id, false).await.unwrap().awareness();
 
     let connection = {
         let server = server.clone();

--- a/crates/y-sweet-worker/src/durable_object.rs
+++ b/crates/y-sweet-worker/src/durable_object.rs
@@ -20,7 +20,12 @@ pub struct YServe {
 
 impl YServe {
     /// We need to lazily create the doc because the constructor is non-async.
-    pub async fn get_doc(&mut self, req: &Request, doc_id: &str, create: bool) -> Result<&mut DocWithSyncKv> {
+    pub async fn get_doc(
+        &mut self,
+        req: &Request,
+        doc_id: &str,
+        create: bool,
+    ) -> Result<&mut DocWithSyncKv> {
         if self.lazy_doc.is_none() {
             let mut context = ServerContext::from_request(req, &self.env).unwrap();
             #[allow(clippy::arc_with_non_send_sync)] // Arc required for compatibility with core.
@@ -109,7 +114,12 @@ async fn websocket_connect(req: Request, ctx: RouteContext<&mut YServe>) -> Resu
     server.accept()?;
 
     let doc_id = ctx.param("doc_id").unwrap().to_owned();
-    let awareness = ctx.data.get_doc(&req, &doc_id, false).await.unwrap().awareness();
+    let awareness = ctx
+        .data
+        .get_doc(&req, &doc_id, false)
+        .await
+        .unwrap()
+        .awareness();
 
     let connection = {
         let server = server.clone();

--- a/crates/y-sweet-worker/src/error.rs
+++ b/crates/y-sweet-worker/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
     CouldNotConstructRequest,
     #[error("Could not forward request to durable object.")]
     CouldNotForwardRequest(worker::Error),
+    #[error("Error creating doc.")]
+    ErrorCreatingDoc(String),
 }
 
 impl Error {
@@ -49,6 +51,7 @@ impl Error {
             Self::InvalidDocName => 400,
             Self::CouldNotConstructRequest => 500,
             Self::CouldNotForwardRequest(_) => 500,
+            Self::ErrorCreatingDoc(_) => 500,
         }
     }
 }

--- a/crates/y-sweet-worker/src/error.rs
+++ b/crates/y-sweet-worker/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use worker::Response;
 use worker_sys::console_error;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Debug)]
 pub enum Error {
     #[error("Expected server auth header.")]
     ExpectedAuthHeader,
@@ -27,6 +27,10 @@ pub enum Error {
     BadRequest,
     #[error("Invalid doc name.")]
     InvalidDocName,
+    #[error("Could not construct request.")]
+    CouldNotConstructRequest,
+    #[error("Could not forward request to durable object.")]
+    CouldNotForwardRequest(worker::Error),
 }
 
 impl Error {
@@ -43,6 +47,8 @@ impl Error {
             Self::InternalError => 500,
             Self::BadRequest => 400,
             Self::InvalidDocName => 400,
+            Self::CouldNotConstructRequest => 500,
+            Self::CouldNotForwardRequest(_) => 500,
         }
     }
 }

--- a/crates/y-sweet-worker/src/lib.rs
+++ b/crates/y-sweet-worker/src/lib.rs
@@ -4,11 +4,9 @@ use error::{Error, IntoResponse};
 use serde_json::{json, Value};
 use server_context::ServerContext;
 use std::collections::HashMap;
-use worker::{
-    console_log, Date, Method, Request, Response, ResponseBody, Result, RouteContext, Router, Url,
-};
 #[cfg(feature = "fetch-event")]
 use worker::{event, Env};
+use worker::{Date, Method, Request, Response, ResponseBody, Result, RouteContext, Router, Url};
 use y_sweet_core::{
     api_types::{validate_doc_name, ClientToken, DocCreationRequest, NewDocResponse},
     auth::Authenticator,
@@ -110,13 +108,11 @@ async fn new_doc(
         String::new()
     };
 
-    console_log!("here0x");
     let req = Request::new(
         &format!("http://ignored/doc/{}{}", doc_id, auth),
         Method::Post,
     )
     .map_err(|_| Error::CouldNotConstructRequest)?;
-    console_log!("here1x");
     let result = forward_to_durable_object_with_doc_id(req, ctx, &doc_id)
         .await
         .map_err(Error::CouldNotForwardRequest)?;
@@ -129,8 +125,6 @@ async fn new_doc(
 
         return Err(Error::ErrorCreatingDoc(body));
     }
-
-    console_log!("here2x");
 
     let response = NewDocResponse { doc_id };
 


### PR DESCRIPTION
When a client attempts to create a new doc with a given name, we first check if the doc exists and if not we put an empty doc on S3. There is a potential race condition where if two requests check if a doc exists, they will both write an empty file. If the file has since changed, those changes will be erased.

I thought this was mostly theoretical, but I want to rule it out as it seems to be happening.

The fix is that, instead of attempting to create the empty file from the stateless worker, we delegate file creation to the durable object itself. This means instantiating the durable object earlier in the connection lifecycle, but has the advantage that the document will only be created if it does not already exist (since there is guaranteed to only be one instance of the durable object).